### PR TITLE
Exclude service quotas for china

### DIFF
--- a/pkg/service_quotas/BUILD
+++ b/pkg/service_quotas/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//third_party/go:aws-sdk-go",
         "//third_party/go:errors",
+        "//third_party/go:logrus"
     ],
 )
 


### PR DESCRIPTION
Currently the service quota service isn't supported in AWS china, we heavily use both AWS standard and china and would love to be able to use this exporter for both environments. Based on my research it's only AWS china which doesn't support service quotas hence why I removed the valid region check. I know this isn't the best implementation as you may want to provide a generic service check for the region specified and disable accordingly. Let me know your thoughts.