### PR TITLE
Fix the count for the rules per security group metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ There are 7 metrics exposed:
 
 1. Rules per security group
 ```
-aws_rules_per_security_group_limit_total{region="eu-west-1",resource="sg-000000000000"} 60
-aws_rules_per_security_group_used_total{region="eu-west-1",resource="sg-000000000000"} 3
+aws_inbound_rules_per_security_group_limit_total{region="eu-west-1",resource="sg-0000000000000"} 200
+aws_inbound_rules_per_security_group_used_total{region="eu-west-1",resource="sg-0000000000000"} 198
+aws_outbound_rules_per_security_group_limit_total{region="eu-west-1",resource="sg-00000000000000"} 200
+aws_outbound_rules_per_security_group_used_total{region="eu-west-1",resource="sg-00000000000000"} 7
 ```
 
 2. Security groups per network interface

--- a/pkg/service_exporter/service_exporter.go
+++ b/pkg/service_exporter/service_exporter.go
@@ -14,10 +14,15 @@ var log = logging.WithFields(logging.Fields{})
 
 // Metric holds usage and limit desc and values
 type Metric struct {
-	usageDesc *prometheus.Desc
-	limitDesc *prometheus.Desc
-	usage     float64
-	limit     float64
+	resourceID string
+	usageDesc  *prometheus.Desc
+	limitDesc  *prometheus.Desc
+	usage      float64
+	limit      float64
+}
+
+func metricKey(quota servicequotas.QuotaUsage) string {
+	return fmt.Sprintf("%s%s", quota.Name, quota.Identifier())
 }
 
 // ServiceQuotasExporter AWS service quotas and usage prometheus
@@ -67,12 +72,12 @@ func (e *ServiceQuotasExporter) updateMetrics() {
 	}
 
 	for _, quota := range quotas {
-		resourceID := quota.Identifier()
-		log.Infof("Refreshing metrics for resource (%s)", resourceID)
-		if resourceMetric, ok := e.metrics[resourceID]; ok {
+		key := metricKey(quota)
+		log.Infof("Refreshing metrics for resource (%s)", quota.Identifier())
+		if resourceMetric, ok := e.metrics[key]; ok {
 			resourceMetric.usage = quota.Usage
 			resourceMetric.limit = quota.Quota
-			e.metrics[resourceID] = resourceMetric
+			e.metrics[key] = resourceMetric
 		}
 	}
 }
@@ -85,8 +90,8 @@ func (e *ServiceQuotasExporter) createQuotasAndDescriptions() {
 
 	for _, quota := range quotas {
 		// check so we don't report the same metric more than once
-		resourceID := quota.Identifier()
-		if _, ok := e.metrics[resourceID]; ok {
+		key := metricKey(quota)
+		if _, ok := e.metrics[key]; ok {
 			continue
 		}
 
@@ -97,12 +102,13 @@ func (e *ServiceQuotasExporter) createQuotasAndDescriptions() {
 		limitDesc := newDesc(e.metricsRegion, quota.Name, "limit_total", limitHelp, []string{"resource"})
 
 		resourceMetric := Metric{
-			usageDesc: usageDesc,
-			limitDesc: limitDesc,
-			usage:     quota.Usage,
-			limit:     quota.Quota,
+			resourceID: quota.Identifier(),
+			usageDesc:  usageDesc,
+			limitDesc:  limitDesc,
+			usage:      quota.Usage,
+			limit:      quota.Quota,
 		}
-		e.metrics[resourceID] = resourceMetric
+		e.metrics[key] = resourceMetric
 	}
 
 	close(e.waitForMetrics)
@@ -120,9 +126,9 @@ func (e *ServiceQuotasExporter) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements the collect function for prometheus collectors
 func (e *ServiceQuotasExporter) Collect(ch chan<- prometheus.Metric) {
-	for resourceID, metric := range e.metrics {
-		ch <- prometheus.MustNewConstMetric(metric.limitDesc, prometheus.GaugeValue, metric.limit, resourceID)
-		ch <- prometheus.MustNewConstMetric(metric.usageDesc, prometheus.GaugeValue, metric.usage, resourceID)
+	for _, metric := range e.metrics {
+		ch <- prometheus.MustNewConstMetric(metric.limitDesc, prometheus.GaugeValue, metric.limit, metric.resourceID)
+		ch <- prometheus.MustNewConstMetric(metric.usageDesc, prometheus.GaugeValue, metric.usage, metric.resourceID)
 	}
 }
 

--- a/pkg/service_exporter/service_exporter_test.go
+++ b/pkg/service_exporter/service_exporter_test.go
@@ -86,17 +86,19 @@ func TestCreateQuotasAndDescriptions(t *testing.T) {
 	secondUsageDesc := newDesc(region, secondQ.Name, "used_total", "Used amount of desc2", []string{"resource"})
 	secondLimitDesc := newDesc(region, secondQ.Name, "limit_total", "Limit of desc2", []string{"resource"})
 	expectedMetrics := map[string]Metric{
-		"i-asdasd1": Metric{
-			usageDesc: firstUsageDesc,
-			limitDesc: firstLimitDesc,
-			usage:     5,
-			limit:     10,
+		"Name1i-asdasd1": Metric{
+			resourceID: "i-asdasd1",
+			usageDesc:  firstUsageDesc,
+			limitDesc:  firstLimitDesc,
+			usage:      5,
+			limit:      10,
 		},
-		"i-asdasd2": Metric{
-			usageDesc: secondUsageDesc,
-			limitDesc: secondLimitDesc,
-			usage:     1,
-			limit:     8,
+		"Name2i-asdasd2": Metric{
+			resourceID: "i-asdasd2",
+			usageDesc:  secondUsageDesc,
+			limitDesc:  secondLimitDesc,
+			usage:      1,
+			limit:      8,
 		},
 	}
 

--- a/pkg/service_quotas/ec2_limits_test.go
+++ b/pkg/service_quotas/ec2_limits_test.go
@@ -69,28 +69,63 @@ func TestRulesPerSecurityGroupUsage(t *testing.T) {
 						{
 							FromPort: aws.Int64(0),
 							ToPort:   aws.Int64(0),
+							UserIdGroupPairs: []*ec2.UserIdGroupPair{
+								{
+									Description: aws.String("Allow workers to communicate with the control plane."),
+									GroupId:     aws.String("sg-0afb91d177e53ae1d"),
+									UserId:      aws.String("740679791268"),
+								},
+							},
+							IpRanges: []*ec2.IpRange{
+								{
+									CidrIp:      aws.String("10.0.0.10/32"),
+									Description: aws.String("Rule A"),
+								},
+								{
+									CidrIp:      aws.String("10.0.0.5/32"),
+									Description: aws.String("Rule B"),
+								},
+							},
 						},
 					},
 					IpPermissionsEgress: []*ec2.IpPermission{
 						{
 							FromPort: aws.Int64(0),
 							ToPort:   aws.Int64(0),
+							IpRanges: []*ec2.IpRange{
+								{
+									CidrIp:      aws.String("0.0.0.0/0"),
+									Description: aws.String("Rule A"),
+								},
+							},
 						},
 					},
 				},
 			},
 			expectedUsage: []QuotaUsage{
 				{
-					Name:         rulesPerSecGrpName,
+					Name:         inboundRulesPerSecGrpName,
 					ResourceName: aws.String("somegroupid"),
-					Description:  rulesPerSecGrpDesc,
+					Description:  inboundRulesPerSecGrpDesc,
 					Usage:        0,
 				},
 				{
-					Name:         rulesPerSecGrpName,
+					Name:         outboundRulesPerSecGrpName,
+					ResourceName: aws.String("somegroupid"),
+					Description:  outboundRulesPerSecGrpDesc,
+					Usage:        0,
+				},
+				{
+					Name:         inboundRulesPerSecGrpName,
 					ResourceName: aws.String("groupwithrules"),
-					Description:  rulesPerSecGrpDesc,
-					Usage:        2,
+					Description:  inboundRulesPerSecGrpDesc,
+					Usage:        3,
+				},
+				{
+					Name:         outboundRulesPerSecGrpName,
+					ResourceName: aws.String("groupwithrules"),
+					Description:  outboundRulesPerSecGrpDesc,
+					Usage:        1,
 				},
 			},
 		},


### PR DESCRIPTION
This also splits up the `aws_rules_per_security_group_limit_total` into `aws_inbound_rules_per_security_group_limit_total` and `aws_outbound_rules_per_security_group_limit_total` and the `aws_rules_per_security_group_used_total` into `aws_inbound_rules_per_security_group_used_total` and `aws_outbound_rules_per_security_group_used_total` as the quota is separate for the inbound and outbound rules.