### PR TITLE
Fix error formatting in FailedToListQuotas

### DIFF
--- a/pkg/service_quotas/service_quotas.go
+++ b/pkg/service_quotas/service_quotas.go
@@ -176,7 +176,7 @@ func (s *ServiceQuotas) quotasForService(service string) ([]QuotaUsage, error) {
 		},
 	)
 	if err != nil {
-		return nil, errors.Wrapf(ErrFailedToListQuotas, "%w", err)
+		return nil, errors.Wrapf(ErrFailedToListQuotas, "%v", err)
 	}
 
 	if usageErr != nil {

--- a/pkg/service_quotas/service_quotas.go
+++ b/pkg/service_quotas/service_quotas.go
@@ -176,7 +176,7 @@ func (s *ServiceQuotas) quotasForService(service string) ([]QuotaUsage, error) {
 		},
 	)
 	if err != nil {
-		return nil, errors.Wrapf(ErrFailedToListQuotas, "%v", err)
+		return nil, errors.Errorf("%w\n%w", ErrFailedToListQuotas, err)
 	}
 
 	if usageErr != nil {


### PR DESCRIPTION
Fixes #26 

Switched error formatting to use `errors.Errorf` instead of `errors.Wrapf`