### PR TITLE
service_exporter: control access to metrics map with a mutex

### DIFF
--- a/pkg/service_exporter/service_exporter_test.go
+++ b/pkg/service_exporter/service_exporter_test.go
@@ -1,6 +1,7 @@
 package serviceexporter
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/service_exporter/service_exporter_test.go
+++ b/pkg/service_exporter/service_exporter_test.go
@@ -38,7 +38,7 @@ func TestUpdateMetrics(t *testing.T) {
 			"i-asdasd1": Metric{usage: 3, limit: 5, labelValues: []string{"before-dummy-value"}},
 			"i-asdasd2": Metric{usage: 2, limit: 2},
 		},
-		metricsLock:     &sync.Mutex,
+		metricsLock:     &sync.Mutex{},
 		includedAWSTags: []string{"dummy-tag"},
 		refreshPeriod:   360,
 	}
@@ -81,7 +81,7 @@ func TestCreateQuotasAndDescriptions(t *testing.T) {
 		metricsRegion:   region,
 		quotasClient:    quotasClient,
 		metrics:         map[string]Metric{},
-		metricsLock:     &sync.Mutex,
+		metricsLock:     &sync.Mutex{},
 		refreshPeriod:   360,
 		waitForMetrics:  ch,
 		includedAWSTags: []string{"dummy-tag", "dummy-tag2"},
@@ -137,7 +137,7 @@ func TestCreateQuotasAndDescriptionsRefresh(t *testing.T) {
 		metrics: map[string]Metric{
 			"i-asdasd1": Metric{usage: 3, limit: 5, labelValues: []string{"before-dummy-value"}, usageDesc: desc},
 		},
-		metricsLock:     &sync.Mutex,
+		metricsLock:     &sync.Mutex{},
 		waitForMetrics:  ch,
 		includedAWSTags: []string{"dummy-tag"},
 		refreshPeriod:   360,

--- a/pkg/service_exporter/service_exporter_test.go
+++ b/pkg/service_exporter/service_exporter_test.go
@@ -37,6 +37,7 @@ func TestUpdateMetrics(t *testing.T) {
 			"i-asdasd1": Metric{usage: 3, limit: 5, labelValues: []string{"before-dummy-value"}},
 			"i-asdasd2": Metric{usage: 2, limit: 2},
 		},
+		metricsLock:     &sync.Mutex,
 		includedAWSTags: []string{"dummy-tag"},
 		refreshPeriod:   360,
 	}
@@ -47,6 +48,8 @@ func TestUpdateMetrics(t *testing.T) {
 		"i-asdasd1": Metric{usage: 5, limit: 10, labelValues: []string{"i-asdasd1", "dummy-value"}},
 		"i-asdasd2": Metric{usage: 2, limit: 3, labelValues: []string{"i-asdasd2", ""}},
 	}
+	exporter.metricsLock.Lock()
+	defer exporter.metricsLock.Unlock()
 	assert.Equal(t, expectedMetrics, exporter.metrics)
 }
 
@@ -77,6 +80,7 @@ func TestCreateQuotasAndDescriptions(t *testing.T) {
 		metricsRegion:   region,
 		quotasClient:    quotasClient,
 		metrics:         map[string]Metric{},
+		metricsLock:     &sync.Mutex,
 		refreshPeriod:   360,
 		waitForMetrics:  ch,
 		includedAWSTags: []string{"dummy-tag", "dummy-tag2"},
@@ -105,6 +109,8 @@ func TestCreateQuotasAndDescriptions(t *testing.T) {
 		},
 	}
 
+	exporter.metricsLock.Lock()
+	defer exporter.metricsLock.Unlock()
 	assert.Equal(t, expectedMetrics, exporter.metrics)
 }
 
@@ -130,6 +136,7 @@ func TestCreateQuotasAndDescriptionsRefresh(t *testing.T) {
 		metrics: map[string]Metric{
 			"i-asdasd1": Metric{usage: 3, limit: 5, labelValues: []string{"before-dummy-value"}, usageDesc: desc},
 		},
+		metricsLock:     &sync.Mutex,
 		waitForMetrics:  ch,
 		includedAWSTags: []string{"dummy-tag"},
 		refreshPeriod:   360,
@@ -141,6 +148,8 @@ func TestCreateQuotasAndDescriptionsRefresh(t *testing.T) {
 		"i-asdasd1": Metric{usage: 5, limit: 10, labelValues: []string{"i-asdasd1", "dummy-value"}, usageDesc: desc},
 	}
 
+	exporter.metricsLock.Lock()
+	defer exporter.metricsLock.Unlock()
 	assert.Equal(t, expectedMetrics, exporter.metrics)
 
 	close(ch) // should panic if it was already closed


### PR DESCRIPTION
In our environment we were having fatal crashes once prometheus scraping and metric refresh happens at the same time because both do operations on `metrics` map of the same `ServiceQuotasExporter` object. 

<details>
  <summary>Crash summary</summary>

```
time="2022-01-30T15:44:16Z" level=info msg="Refreshing metrics for resource (sg-xxx)"
fatal error: concurrent map iteration and map write

goroutine 86541 [running]:
runtime.throw(0x1048f22, 0x26)
        /usr/local/go/src/runtime/panic.go:774 +0x72 fp=0xc000e75d10 sp=0xc000e75ce0 pc=0x42fe32
runtime.mapiternext(0xc000e75e68)
        /usr/local/go/src/runtime/map.go:858 +0x579 fp=0xc000e75d98 sp=0xc000e75d10 pc=0x410c59
github.com/thought-machine/aws-service-quotas-exporter/pkg/service_exporter/serviceexporter.(*ServiceQuotasExporter).Collect(0xc0001bc410, 0xc0006b5f80)
        pkg/service_exporter/service_exporter.go:136 +0xba fp=0xc000e75ed8 sp=0xc000e75d98 pc=0xd0ca1a
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
        third_party/go/src/github.com/prometheus/client_golang/prometheus/registry.go:444 +0x19d fp=0xc000e75fe0 sp=0xc000e75ed8 pc=0x86ac9d
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc000e75fe8 sp=0xc000e75fe0 pc=0x45c731
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
        third_party/go/src/github.com/prometheus/client_golang/prometheus/registry.go:455 +0x57d

goroutine 1 [IO wait]:
internal/poll.runtime_pollWait(0x7fc1deb43bc8, 0x72, 0x0)
        /usr/local/go/src/runtime/netpoll.go:184 +0x55
internal/poll.(*pollDesc).wait(0xc00106e018, 0x72, 0x0, 0x0, 0x102d583)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Accept(0xc00106e000, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/internal/poll/fd_unix.go:384 +0x1f8
net.(*netFD).accept(0xc00106e000, 0xc001588ca8, 0x6cfdf4, 0xc0004f8260)
        /usr/local/go/src/net/fd_unix.go:238 +0x42
net.(*TCPListener).accept(0xc0003ce320, 0x61f6b247, 0xc001588ca8, 0x4bce36)
        /usr/local/go/src/net/tcpsock_posix.go:139 +0x32
net.(*TCPListener).Accept(0xc0003ce320, 0xc001588cf8, 0x18, 0xc000000180, 0x6cf30e)
        /usr/local/go/src/net/tcpsock.go:261 +0x47
net/http.(*Server).Serve(0xc0004f81c0, 0x12a61c0, 0xc0003ce320, 0x0, 0x0)
        /usr/local/go/src/net/http/server.go:2896 +0x286
net/http.(*Server).ListenAndServe(0xc0004f81c0, 0xc0004f81c0, 0xc0001b3f30)
        /usr/local/go/src/net/http/server.go:2825 +0xb7
net/http.ListenAndServe(...)
        /usr/local/go/src/net/http/server.go:3080
main.main()
        cmd/main.go:40 +0x371

goroutine 35 [runnable]:
strconv.appendEscapedRune(0xc000168138, 0x15, 0x44, 0x220000006f, 0xc000168138, 0x15, 0x44)
        /usr/local/go/src/strconv/quote.go:64 +0xb35
strconv.appendQuotedWith(0xc000168138, 0x15, 0x44, 0xc00117f5d4, 0x19, 0x22, 0xc000168138, 0x16, 0x44)
        /usr/local/go/src/strconv/quote.go:48 +0x2c8
strconv.AppendQuote(...)
        /usr/local/go/src/strconv/quote.go:131
fmt.(*fmt).fmtQ(0xc000168110, 0xc00117f5c0, 0x2d)
        /usr/local/go/src/fmt/format.go:457 +0x117
fmt.(*pp).fmtString(0xc0001680d0, 0xc00117f5c0, 0x2d, 0xc000000071)
        /usr/local/go/src/fmt/print.go:456 +0x7c
fmt.(*pp).printArg(0xc0001680d0, 0xdcc280, 0xc0001eadf0, 0x71)
        /usr/local/go/src/fmt/print.go:698 +0x877
fmt.(*pp).doPrintf(0xc0001680d0, 0x102ba1c, 0x2, 0xc0007c93d0, 0x1, 0x1)
        /usr/local/go/src/fmt/print.go:1030 +0x15b
fmt.Sprintf(0x102ba1c, 0x2, 0xc0007c93d0, 0x1, 0x1, 0x0, 0x4e61e8)
        /usr/local/go/src/fmt/print.go:219 +0x66
github.com/sirupsen/logrus.(*TextFormatter).appendValue(0xc000186060, 0xc000ed2030, 0xdcc280, 0xc0001ead90)
        third_party/go/src/github.com/sirupsen/logrus/text_formatter.go:332 +0xe3
github.com/sirupsen/logrus.(*TextFormatter).appendKeyValue(0xc000186060, 0xc000ed2030, 0x102bf8a, 0x3, 0xdcc280, 0xc0001ead90)
        third_party/go/src/github.com/sirupsen/logrus/text_formatter.go:320 +0x8f
github.com/sirupsen/logrus.(*TextFormatter).Format(0xc000186060, 0xc0006d81c0, 0xc0006d81c0, 0x0, 0x0, 0x4d4e71, 0x4793f2)
        third_party/go/src/github.com/sirupsen/logrus/text_formatter.go:221 +0xa32
github.com/sirupsen/logrus.(*Entry).write(0xc0006d81c0)
        third_party/go/src/github.com/sirupsen/logrus/entry.go:275 +0xa1
github.com/sirupsen/logrus.Entry.log(0xc0001a2000, 0xc0002d0090, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        third_party/go/src/github.com/sirupsen/logrus/entry.go:251 +0x1c1
github.com/sirupsen/logrus.(*Entry).Log(0xc0002bacb0, 0x4, 0xc0007c9c28, 0x1, 0x1)
        third_party/go/src/github.com/sirupsen/logrus/entry.go:287 +0xeb
github.com/sirupsen/logrus.(*Entry).Logf(0xc0002bacb0, 0x4, 0x1046907, 0x24, 0xc0007c9d80, 0x1, 0x1)
        third_party/go/src/github.com/sirupsen/logrus/entry.go:333 +0xe2
github.com/sirupsen/logrus.(*Entry).Infof(...)
        third_party/go/src/github.com/sirupsen/logrus/entry.go:346
github.com/thought-machine/aws-service-quotas-exporter/pkg/service_exporter/serviceexporter.(*ServiceQuotasExporter).createQuotasAndDescriptions(0xc0001bc410, 0x1)
        pkg/service_exporter/service_exporter.go:96 +0x7ba
github.com/thought-machine/aws-service-quotas-exporter/pkg/service_exporter/serviceexporter.(*ServiceQuotasExporter).updateMetrics(...)
        pkg/service_exporter/service_exporter.go:71
github.com/thought-machine/aws-service-quotas-exporter/pkg/service_exporter/serviceexporter.(*ServiceQuotasExporter).refreshMetrics(0xc0001bc410)
        pkg/service_exporter/service_exporter.go:66 +0x65
created by github.com/thought-machine/aws-service-quotas-exporter/pkg/service_exporter/serviceexporter.NewServiceQuotasExporter
        pkg/service_exporter/service_exporter.go:56 +0x1ac

goroutine 1687 [IO wait]:
internal/poll.runtime_pollWait(0x7fc1deb43c98, 0x72, 0xffffffffffffffff)
        /usr/local/go/src/runtime/netpoll.go:184 +0x55
internal/poll.(*pollDesc).wait(0xc001846998, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc001846980, 0xc0011d0000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/local/go/src/internal/poll/fd_unix.go:169 +0x1cf
net.(*netFD).Read(0xc001846980, 0xc0011d0000, 0x1000, 0x1000, 0x0, 0x0, 0xc000f87818)
        /usr/local/go/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc000ade9b8, 0xc0011d0000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/net.go:184 +0x68
net/http.(*connReader).Read(0xc000b6c240, 0xc0011d0000, 0x1000, 0x1000, 0xc0006b8160, 0x1, 0x203000)
        /usr/local/go/src/net/http/server.go:785 +0xf4
bufio.(*Reader).fill(0xc0011cc000)
        /usr/local/go/src/bufio/bufio.go:100 +0x103
bufio.(*Reader).ReadSlice(0xc0011cc000, 0xa, 0x28, 0xc000f879a8, 0x40d956, 0xc000939500, 0x100)
        /usr/local/go/src/bufio/bufio.go:359 +0x3d
bufio.(*Reader).ReadLine(0xc0011cc000, 0xc000f879b0, 0xc0000f9500, 0x7fc1e0e5f6d0, 0x0, 0x40e1c8, 0x30)
        /usr/local/go/src/bufio/bufio.go:388 +0x34
net/textproto.(*Reader).readLineSlice(0xc0006cf410, 0xc000939500, 0xc001846980, 0x0, 0x0, 0x431c5c)
        /usr/local/go/src/net/textproto/reader.go:57 +0x6c
net/textproto.(*Reader).ReadLine(...)
        /usr/local/go/src/net/textproto/reader.go:38
net/http.readRequest(0xc0011cc000, 0x0, 0xc000939500, 0x0, 0x0)
        /usr/local/go/src/net/http/request.go:1012 +0x92
net/http.(*conn).readRequest(0xc000464c80, 0x12aa7c0, 0xc000c1ccc0, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/http/server.go:965 +0x15f
net/http.(*conn).serve(0xc000464c80, 0x12aa7c0, 0xc000c1ccc0)
        /usr/local/go/src/net/http/server.go:1817 +0x6d4
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:2927 +0x38e

goroutine 1681 [runnable]:
github.com/prometheus/client_golang/prometheus.checkLabelName(0x102dffc, 0x8, 0x897443d765590c01)
        third_party/go/src/github.com/prometheus/client_golang/prometheus/labels.go:85 +0x8d
github.com/prometheus/client_golang/prometheus.checkMetricConsistency(0xc00016da40, 0xc000625ea0, 0xc000f83590, 0x1, 0xc000e3ab18)
        third_party/go/src/github.com/prometheus/client_golang/prometheus/registry.go:859 +0x221
github.com/prometheus/client_golang/prometheus.processMetric(0x12a0460, 0xc000f330b0, 0xc000f83560, 0xc000f83590, 0x0, 0x0, 0x0)
        third_party/go/src/github.com/prometheus/client_golang/prometheus/registry.go:671 +0x3c5
github.com/prometheus/client_golang/prometheus.(*Registry).Gather(0xc0000b6780, 0x0, 0x0, 0x0, 0x0, 0x0)
        third_party/go/src/github.com/prometheus/client_golang/prometheus/registry.go:490 +0x85e
github.com/prometheus/client_golang/prometheus/promhttp.HandlerFor.func1(0x7fc1deb136f0, 0xc00048c1e0, 0xc00019f500)
        third_party/go/src/github.com/prometheus/client_golang/prometheus/promhttp/http.go:126 +0x65
net/http.HandlerFunc.ServeHTTP(0xc0006be150, 0x7fc1deb136f0, 0xc00048c1e0, 0xc00019f500)
        /usr/local/go/src/net/http/server.go:2007 +0x44
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerInFlight.func1(0x7fc1deb136f0, 0xc00048c1e0, 0xc00019f500)
        third_party/go/src/github.com/prometheus/client_golang/prometheus/promhttp/instrument_server.go:40 +0xbc
net/http.HandlerFunc.ServeHTTP(0xc0006c4270, 0x7fc1deb136f0, 0xc00048c1e0, 0xc00019f500)
        /usr/local/go/src/net/http/server.go:2007 +0x44
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1(0x12a6480, 0xc0004f8460, 0xc00019f500)
        third_party/go/src/github.com/prometheus/client_golang/prometheus/promhttp/instrument_server.go:100 +0xda
net/http.HandlerFunc.ServeHTTP(0xc0006c4360, 0x12a6480, 0xc0004f8460, 0xc00019f500)
        /usr/local/go/src/net/http/server.go:2007 +0x44
net/http.(*ServeMux).ServeHTTP(0x19ecbc0, 0x12a6480, 0xc0004f8460, 0xc00019f500)
        /usr/local/go/src/net/http/server.go:2387 +0x1bd
net/http.serverHandler.ServeHTTP(0xc0004f81c0, 0x12a6480, 0xc0004f8460, 0xc00019f500)
        /usr/local/go/src/net/http/server.go:2802 +0xa4
net/http.(*conn).serve(0xc0004650e0, 0x12aa7c0, 0xc000c1cdc0)
        /usr/local/go/src/net/http/server.go:1890 +0x875
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:2927 +0x38e

goroutine 86502 [IO wait]:
internal/poll.runtime_pollWait(0x7fc1deb43d68, 0x72, 0xffffffffffffffff)
        /usr/local/go/src/runtime/netpoll.go:184 +0x55
internal/poll.(*pollDesc).wait(0xc00106f118, 0x72, 0x3b00, 0x3bcb, 0xffffffffffffffff)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00106f100, 0xc000830000, 0x3bcb, 0x3bcb, 0x0, 0x0, 0x0)
        /usr/local/go/src/internal/poll/fd_unix.go:169 +0x1cf
net.(*netFD).Read(0xc00106f100, 0xc000830000, 0x3bcb, 0x3bcb, 0x203000, 0x0, 0x3a16)
        /usr/local/go/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc000ade310, 0xc000830000, 0x3bcb, 0x3bcb, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/net.go:184 +0x68
crypto/tls.(*atLeastReader).Read(0xc000b5a040, 0xc000830000, 0x3bcb, 0x3bcb, 0x20, 0x400, 0xc001585970)
        /usr/local/go/src/crypto/tls/conn.go:780 +0x60
bytes.(*Buffer).ReadFrom(0xc000089058, 0x1296840, 0xc000b5a040, 0x40b935, 0xeb4a80, 0xff5ac0)
        /usr/local/go/src/bytes/buffer.go:204 +0xb4
crypto/tls.(*Conn).readFromUntil(0xc000088e00, 0x12971a0, 0xc000ade310, 0x5, 0xc000ade310, 0x9)
        /usr/local/go/src/crypto/tls/conn.go:802 +0xec
crypto/tls.(*Conn).readRecordOrCCS(0xc000088e00, 0x0, 0x0, 0x459570)
        /usr/local/go/src/crypto/tls/conn.go:609 +0x124
crypto/tls.(*Conn).readRecord(...)
        /usr/local/go/src/crypto/tls/conn.go:577
crypto/tls.(*Conn).Read(0xc000088e00, 0xc000817000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/local/go/src/crypto/tls/conn.go:1255 +0x161
bufio.(*Reader).Read(0xc001929a40, 0xc0004f9a78, 0x9, 0x9, 0xc001585d10, 0x0, 0x6b3a52)
        /usr/local/go/src/bufio/bufio.go:226 +0x26a
io.ReadAtLeast(0x12966a0, 0xc001929a40, 0xc0004f9a78, 0x9, 0x9, 0x9, 0xc000020070, 0x0, 0x12969c0)
        /usr/local/go/src/io/io.go:310 +0x87
io.ReadFull(...)
        /usr/local/go/src/io/io.go:329
net/http.http2readFrameHeader(0xc0004f9a78, 0x9, 0x9, 0x12966a0, 0xc001929a40, 0x0, 0x0, 0xc000b4a120, 0x0)
        /usr/local/go/src/net/http/h2_bundle.go:1477 +0x87
net/http.(*http2Framer).ReadFrame(0xc0004f9a40, 0xc000b4a120, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/http/h2_bundle.go:1735 +0xa1
net/http.(*http2clientConnReadLoop).run(0xc001585fb8, 0x68d99d, 0xc0001821e0)
        /usr/local/go/src/net/http/h2_bundle.go:8175 +0x8e
net/http.(*http2ClientConn).readLoop(0xc000a16180)
        /usr/local/go/src/net/http/h2_bundle.go:8103 +0xa3
created by net/http.(*http2Transport).newClientConn
        /usr/local/go/src/net/http/h2_bundle.go:7162 +0x62f

goroutine 86518 [select]:
net/http.(*persistConn).writeLoop(0xc0002eec60)
        /usr/local/go/src/net/http/transport.go:2196 +0x123
created by net/http.(*Transport).dialConn
        /usr/local/go/src/net/http/transport.go:1567 +0xb23

goroutine 86542 [semacquire]:
sync.runtime_Semacquire(0xc00075dab8)
        /usr/local/go/src/runtime/sema.go:56 +0x42
sync.(*WaitGroup).Wait(0xc00075dab0)
        /usr/local/go/src/sync/waitgroup.go:130 +0x64
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func2(0xc00075dab0, 0xc0006b5f80, 0xc000e30000)
        third_party/go/src/github.com/prometheus/client_golang/prometheus/registry.go:461 +0x2b
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
        third_party/go/src/github.com/prometheus/client_golang/prometheus/registry.go:460 +0x5bc

goroutine 86517 [IO wait]:
internal/poll.runtime_pollWait(0x7fc1deb43888, 0x72, 0xffffffffffffffff)
        /usr/local/go/src/runtime/netpoll.go:184 +0x55
internal/poll.(*pollDesc).wait(0xc00106f618, 0x72, 0xba00, 0xbaee, 0xffffffffffffffff)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00106f600, 0xc000bba000, 0xbaee, 0xbaee, 0x0, 0x0, 0x0)
        /usr/local/go/src/internal/poll/fd_unix.go:169 +0x1cf
net.(*netFD).Read(0xc00106f600, 0xc000bba000, 0xbaee, 0xbaee, 0x203000, 0x0, 0xbae1)
        /usr/local/go/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc000f3a560, 0xc000bba000, 0xbaee, 0xbaee, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/net.go:184 +0x68
crypto/tls.(*atLeastReader).Read(0xc000b48100, 0xc000bba000, 0xbaee, 0xbaee, 0x28, 0x8, 0xc0015898a0)
        /usr/local/go/src/crypto/tls/conn.go:780 +0x60
bytes.(*Buffer).ReadFrom(0xc000271058, 0x1296840, 0xc000b48100, 0x40b935, 0xeb4a80, 0xff5ac0)
        /usr/local/go/src/bytes/buffer.go:204 +0xb4
crypto/tls.(*Conn).readFromUntil(0xc000270e00, 0x12971a0, 0xc000f3a560, 0x5, 0xc000f3a560, 0x1f)
        /usr/local/go/src/crypto/tls/conn.go:802 +0xec
crypto/tls.(*Conn).readRecordOrCCS(0xc000270e00, 0x0, 0x0, 0x3)
        /usr/local/go/src/crypto/tls/conn.go:609 +0x124
crypto/tls.(*Conn).readRecord(...)
        /usr/local/go/src/crypto/tls/conn.go:577
crypto/tls.(*Conn).Read(0xc000270e00, 0xc000865000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/local/go/src/crypto/tls/conn.go:1255 +0x161
net/http.(*persistConn).Read(0xc0002eec60, 0xc000865000, 0x1000, 0x1000, 0xc00054f440, 0xc001589c20, 0x4068a5)
        /usr/local/go/src/net/http/transport.go:1744 +0x75
bufio.(*Reader).fill(0xc001066540)
        /usr/local/go/src/bufio/bufio.go:100 +0x103
bufio.(*Reader).Peek(0xc001066540, 0x1, 0x0, 0x0, 0x1, 0xc00054e100, 0x0)
        /usr/local/go/src/bufio/bufio.go:138 +0x4f
net/http.(*persistConn).readLoop(0xc0002eec60)
        /usr/local/go/src/net/http/transport.go:1897 +0x1d6
created by net/http.(*Transport).dialConn
        /usr/local/go/src/net/http/transport.go:1566 +0xafe

goroutine 86523 [select]:
net/http.(*persistConn).writeLoop(0xc0007aab40)
        /usr/local/go/src/net/http/transport.go:2196 +0x123
created by net/http.(*Transport).dialConn
        /usr/local/go/src/net/http/transport.go:1567 +0xb23

goroutine 86522 [IO wait]:
internal/poll.runtime_pollWait(0x7fc1deb43a28, 0x72, 0xffffffffffffffff)
        /usr/local/go/src/runtime/netpoll.go:184 +0x55
internal/poll.(*pollDesc).wait(0xc000c1a198, 0x72, 0x1800, 0x18b3, 0xffffffffffffffff)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc000c1a180, 0xc000c4a000, 0x18b3, 0x18b3, 0x0, 0x0, 0x0)
        /usr/local/go/src/internal/poll/fd_unix.go:169 +0x1cf
net.(*netFD).Read(0xc000c1a180, 0xc000c4a000, 0x18b3, 0x18b3, 0x203000, 0x0, 0x18a6)
        /usr/local/go/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc000b9c050, 0xc000c4a000, 0x18b3, 0x18b3, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/net.go:184 +0x68
crypto/tls.(*atLeastReader).Read(0xc000b687a0, 0xc000c4a000, 0x18b3, 0x18b3, 0x28, 0x8, 0xc0000698a0)
        /usr/local/go/src/crypto/tls/conn.go:780 +0x60
bytes.(*Buffer).ReadFrom(0xc0001f6958, 0x1296840, 0xc000b687a0, 0x40b935, 0xeb4a80, 0xff5ac0)
        /usr/local/go/src/bytes/buffer.go:204 +0xb4
crypto/tls.(*Conn).readFromUntil(0xc0001f6700, 0x12971a0, 0xc000b9c050, 0x5, 0xc000b9c050, 0xc000069930)
        /usr/local/go/src/crypto/tls/conn.go:802 +0xec
crypto/tls.(*Conn).readRecordOrCCS(0xc0001f6700, 0x0, 0x0, 0x3)
        /usr/local/go/src/crypto/tls/conn.go:609 +0x124
crypto/tls.(*Conn).readRecord(...)
        /usr/local/go/src/crypto/tls/conn.go:577
crypto/tls.(*Conn).Read(0xc0001f6700, 0xc000c74000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/local/go/src/crypto/tls/conn.go:1255 +0x161
net/http.(*persistConn).Read(0xc0007aab40, 0xc000c74000, 0x1000, 0x1000, 0xc00054eb40, 0xc000069c20, 0x4068a5)
        /usr/local/go/src/net/http/transport.go:1744 +0x75
bufio.(*Reader).fill(0xc000c18420)
        /usr/local/go/src/bufio/bufio.go:100 +0x103
bufio.(*Reader).Peek(0xc000c18420, 0x1, 0x0, 0x0, 0x1, 0xc0002e4300, 0x0)
        /usr/local/go/src/bufio/bufio.go:138 +0x4f
net/http.(*persistConn).readLoop(0xc0007aab40)
        /usr/local/go/src/net/http/transport.go:1897 +0x1d6
created by net/http.(*Transport).dialConn
        /usr/local/go/src/net/http/transport.go:1566 +0xafe

goroutine 86540 [IO wait]:
internal/poll.runtime_pollWait(0x7fc1deb43af8, 0x72, 0xffffffffffffffff)
        /usr/local/go/src/runtime/netpoll.go:184 +0x55
internal/poll.(*pollDesc).wait(0xc001d11518, 0x72, 0x0, 0x1, 0xffffffffffffffff)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc001d11500, 0xc000c48d61, 0x1, 0x1, 0x0, 0x0, 0x0)
        /usr/local/go/src/internal/poll/fd_unix.go:169 +0x1cf
net.(*netFD).Read(0xc001d11500, 0xc000c48d61, 0x1, 0x1, 0xc000338480, 0x3, 0xc0005b6f88)
        /usr/local/go/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc000f3aaa8, 0xc000c48d61, 0x1, 0x1, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/net.go:184 +0x68
net/http.(*connReader).backgroundRead(0xc000c48d50)
        /usr/local/go/src/net/http/server.go:677 +0x58
created by net/http.(*connReader).startBackgroundRead
        /usr/local/go/src/net/http/server.go:673 +0xd4
```

</details>

We forked the project, built it with `-race` compiler flag, ran and started scraping it every second, every time it tried to refresh metrics we saw a race condition:

<details>
  <summary>Race condition summary</summary>
  
```
INFO[0005] Serving on port: 9090
INFO[0005] Serving Prometheus metrics on /metrics
INFO[0371] Updating metrics for resource (spot_instance_requests)
INFO[0371] Updating metrics for resource (ondemand_instance_requests)
INFO[0371] Updating metrics for resource (sg-xxx)
INFO[0371] Updating metrics for resource (sg-xxx)
INFO[0371] Updating metrics for resource (sg-xxx)
INFO[0371] Updating metrics for resource (sg-xxx)
INFO[0371] Updating metrics for resource (security_groups_per_region)
INFO[0371] Updating metrics for resource (subnet-xxx)
INFO[0371] Updating metrics for resource (subnet-xxx)
INFO[0371] Updating metrics for resource (subnet-xxx)
INFO[0371] Updating metrics for resource (subnet-xxx)
INFO[0371] Updating metrics for resource (subnet-xxx)
INFO[0371] Updating metrics for resource (subnet-xxx)
==================
WARNING: DATA RACE
Read at 0x00c000020c60 by goroutine 8:
  runtime.mapdelete()
      /opt/homebrew/Cellar/go/1.17.3/libexec/src/runtime/map.go:685 +0x49c
  github.com/peak/aws-service-quotas-exporter/pkg/service_exporter.(*ServiceQuotasExporter).Collect()
      /Users/serhat/workspace/github/aws-service-quotas-exporter/pkg/service_exporter/service_exporter.go:132 +0x78
  github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
      /Users/serhat/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/registry.go:446 +0x10c

Previous write at 0x00c000020c60 by goroutine 10:
  runtime.mapaccess2_faststr()
      /opt/homebrew/Cellar/go/1.17.3/libexec/src/runtime/map_faststr.go:107 +0x48c
  github.com/peak/aws-service-quotas-exporter/pkg/service_exporter.(*ServiceQuotasExporter).createOrUpdateQuotasAndDescriptions()
      /Users/serhat/workspace/github/aws-service-quotas-exporter/pkg/service_exporter/service_exporter.go:96 +0x5a0
  github.com/peak/aws-service-quotas-exporter/pkg/service_exporter.(*ServiceQuotasExporter).refreshMetrics()
      /Users/serhat/workspace/github/aws-service-quotas-exporter/pkg/service_exporter/service_exporter.go:66 +0x8c

Goroutine 8 (running) created at:
  github.com/prometheus/client_golang/prometheus.(*Registry).Gather()
      /Users/serhat/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/registry.go:538 +0xdec
  github.com/prometheus/client_golang/prometheus/promhttp.HandlerFor.func1()
      /Users/serhat/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/promhttp/http.go:126 +0xb4
  net/http.HandlerFunc.ServeHTTP()
      /opt/homebrew/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x48
  github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerInFlight.func1()
      /Users/serhat/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/promhttp/instrument_server.go:40 +0xb4
  net/http.HandlerFunc.ServeHTTP()
      /opt/homebrew/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x48
  github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1()
      /Users/serhat/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/promhttp/instrument_server.go:117 +0xc4
  net/http.HandlerFunc.ServeHTTP()
      /opt/homebrew/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x48
  net/http.(*ServeMux).ServeHTTP()
      /opt/homebrew/Cellar/go/1.17.3/libexec/src/net/http/server.go:2424 +0xb4
  net/http.serverHandler.ServeHTTP()
      /opt/homebrew/Cellar/go/1.17.3/libexec/src/net/http/server.go:2878 +0x7dc
  net/http.(*conn).serve()
      /opt/homebrew/Cellar/go/1.17.3/libexec/src/net/http/server.go:1929 +0x11a8

Goroutine 10 (running) created at:
  github.com/peak/aws-service-quotas-exporter/pkg/service_exporter.NewServiceQuotasExporter()
      /Users/serhat/workspace/github/aws-service-quotas-exporter/pkg/service_exporter/service_exporter.go:56 +0x248
  main.main()
      /Users/serhat/workspace/github/aws-service-quotas-exporter/main.go:26 +0x12c
==================
==================
WARNING: DATA RACE
Read at 0x00c00064b360 by goroutine 8:
  github.com/peak/aws-service-quotas-exporter/pkg/service_exporter.(*ServiceQuotasExporter).Collect()
      /Users/serhat/workspace/github/aws-service-quotas-exporter/pkg/service_exporter/service_exporter.go:132 +0xd0
  github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
      /Users/serhat/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/registry.go:446 +0x10c

Previous write at 0x00c00064b360 by goroutine 10:
  github.com/peak/aws-service-quotas-exporter/pkg/service_exporter.(*ServiceQuotasExporter).createOrUpdateQuotasAndDescriptions()
      /Users/serhat/workspace/github/aws-service-quotas-exporter/pkg/service_exporter/service_exporter.go:96 +0x5bc
  github.com/peak/aws-service-quotas-exporter/pkg/service_exporter.(*ServiceQuotasExporter).refreshMetrics()
      /Users/serhat/workspace/github/aws-service-quotas-exporter/pkg/service_exporter/service_exporter.go:66 +0x8c

Goroutine 8 (running) created at:
  github.com/prometheus/client_golang/prometheus.(*Registry).Gather()
      /Users/serhat/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/registry.go:538 +0xdec
  github.com/prometheus/client_golang/prometheus/promhttp.HandlerFor.func1()
      /Users/serhat/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/promhttp/http.go:126 +0xb4
  net/http.HandlerFunc.ServeHTTP()
      /opt/homebrew/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x48
  github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerInFlight.func1()
      /Users/serhat/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/promhttp/instrument_server.go:40 +0xb4
  net/http.HandlerFunc.ServeHTTP()
      /opt/homebrew/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x48
  github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1()
      /Users/serhat/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/promhttp/instrument_server.go:117 +0xc4
  net/http.HandlerFunc.ServeHTTP()
      /opt/homebrew/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x48
  net/http.(*ServeMux).ServeHTTP()
      /opt/homebrew/Cellar/go/1.17.3/libexec/src/net/http/server.go:2424 +0xb4
  net/http.serverHandler.ServeHTTP()
      /opt/homebrew/Cellar/go/1.17.3/libexec/src/net/http/server.go:2878 +0x7dc
  net/http.(*conn).serve()
      /opt/homebrew/Cellar/go/1.17.3/libexec/src/net/http/server.go:1929 +0x11a8

Goroutine 10 (running) created at:
  github.com/peak/aws-service-quotas-exporter/pkg/service_exporter.NewServiceQuotasExporter()
      /Users/serhat/workspace/github/aws-service-quotas-exporter/pkg/service_exporter/service_exporter.go:56 +0x248
  main.main()
      /Users/serhat/workspace/github/aws-service-quotas-exporter/main.go:26 +0x12c
==================
```

</details>

This is caused by concurrent access to `metrics` field of `ServiceQuotasExporter` object. Refresh operation tries to read from and write to it and Collect function tries to read it at the same time. To overcome this we added a `*sync.Mutex` field to `ServiceQuotasExporter` struct and locked it before accessing the map. 

With this improvement there are no crashes anymore and requests to `/metrics` endpoint don't stall. After merging this can you create another release plus a docker image so we can continue using upstream version, not forked.