### PR TITLE
Fix `x509: certificate signed by unknown authority` using container image v1.3.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -21,6 +21,7 @@ FROM scratch
 
 EXPOSE 9090
 
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/github.com/thought-machine/aws-service-quotas-exporter/aws-service-quotas-exporter /home/app/aws-service-quotas-exporter
 
 COPY --from=0 /etc/passwd /etc/passwd


### PR DESCRIPTION
## Input

After the update to `v1.3.0` the exporter crashes with the error:

```console
time="2022-12-..." level=fatal msg="Could not retrieve quotas and limits: failed to list quotas: WebIdentityErr: failed to retrieve credentials\ncaused by: RequestError: send request failed\ncaused by: 

Post "https://sts.amazonaws.com/": x509: certificate signed by unknown authority"
```
## Expected

No crashes

## Suggested Fix

The latest `Dockerfile` uses now `FROM scratch` as base image, which is missing the certs files.
Adding the OS `ca-certificates` to the container image fixed this issue on our side.

## Verification

- Checkout this branch and build the container image via:

```console
docker build -t local/aws-service-quotas-exporter:v0 -f build/Dockerfile .
```
- Run the container via:

```console
docker run --rm\
 -e AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id)\
 -e AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key)\
 -e AWS_SESSION_TOKEN=$(aws configure get aws_session_token)\
 local/aws-service-quotas-exporter:v0 --region=us-east-1
```
- Output:

```console
time="2022-12-..." level=info msg="Serving on port: 9090"
time="2022-12-..." level=info msg="Serving Prometheus metrics on /metrics"
```